### PR TITLE
Add terminateAllThreads()

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ worker.once('error', (error) => {
 });
 ```
 
+### Terminating All Threads
+By calling `terminateAllThreads()`, you can terminate all worker threads that have been started with `launch()`. The return value is an array of exit codes.
+
+```typescript
+import { terminateAllThreads } from "sync-actions";
+
+const exitCodes = await terminateAllThreads();
+```
+
 ## Environment Variables
 
 ### `DISABLE_SYNC_ACTIONS`

--- a/tests/multi.test.ts
+++ b/tests/multi.test.ts
@@ -1,3 +1,4 @@
+import { terminateAllThreads } from "../src";
 import actions from "./worker";
 
 
@@ -9,4 +10,18 @@ test("launch multiple workers", async () => {
   client1.worker.terminate();
   expect(client2.actions.magic(0)).toBe(2);
   client2.worker.terminate();
+});
+
+test("terminateAllThreads()", async () => {
+  const client1 = actions.launch();
+  const client2 = actions.launch();
+  const client3 = actions.launch();
+  expect(await client3.worker.terminate()).toBe(0)
+
+  await terminateAllThreads();
+
+  // all threads are already terminated
+  expect(await client1.worker.terminate()).toBeUndefined();
+  expect(await client2.worker.terminate()).toBeUndefined();
+  expect(await client3.worker.terminate()).toBeUndefined();
 });


### PR DESCRIPTION
### Terminating All Threads
By calling `terminateAllThreads()`, you can terminate all worker threads that have been started with `launch()`. The return value is an array of exit codes.

```typescript
import { terminateAllThreads } from "sync-actions";

const exitCodes = await terminateAllThreads();
```