### PR TITLE
Try executing with the original file if writing to tmp file fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,10 @@ const prepareExecuteFile = (filepath: string) => {
     ) {
       // When running in AWS Lambda, the file system is read-only, so writing may fail.
       // However, libraries might already be in a format executable by Node.js, so try running with the original file.
+      // Log a warning message when fallback to original file
+      console.warn(
+        `[sync-actions]: Failed to write compiled worker file. Falling back to original file: ${filepath}`
+      );
       return filepath;
     }
     throw e;

--- a/tests/jsWoker.test.ts
+++ b/tests/jsWoker.test.ts
@@ -1,0 +1,32 @@
+import client from "./jsWorker";
+
+let errorMessage = "foo";
+vi.mock("esbuild", async () => {
+  const esbuild = await vi.importActual<typeof import("esbuild")>("esbuild");
+  return {
+    buildSync: vi.fn((...args) => {
+      if (errorMessage) throw new Error(errorMessage);
+      // @ts-ignore
+      return esbuild.buildSync(...args);
+    }),
+  };
+});
+
+test("should successfully launch and ping when no error occurs", async () => {
+  errorMessage = "";
+  const { actions, worker } = client.launch();
+  expect(actions.ping()).toBe("pong!?");
+  worker.terminate();
+});
+
+test("should work correctly when buildSync encounters a write error", async () => {
+  errorMessage = "Failed to create output directory: mkdir /var/task/node_modules/.sync-action-workers: read-only file system";
+  const { actions, worker } = client.launch();
+  expect(actions.ping()).toBe("pong!?");
+  worker.terminate();
+});
+
+test("should throw an error when buildSync fails with a non-write error", async () => {
+  errorMessage = "Other Error";
+  expect(client.launch).toThrow(Error);
+});

--- a/tests/jsWoker.test.ts
+++ b/tests/jsWoker.test.ts
@@ -21,9 +21,12 @@ test("should successfully launch and ping when no error occurs", async () => {
 
 test("should work correctly when buildSync encounters a write error", async () => {
   errorMessage = "Failed to create output directory: mkdir /var/task/node_modules/.sync-action-workers: read-only file system";
+  const originalWarn = console.warn;
+  console.warn = vi.fn();
   const { actions, worker } = client.launch();
   expect(actions.ping()).toBe("pong!?");
   worker.terminate();
+  console.warn = originalWarn;
 });
 
 test("should throw an error when buildSync fails with a non-write error", async () => {

--- a/tests/jsWorker.d.ts
+++ b/tests/jsWorker.d.ts
@@ -1,0 +1,9 @@
+declare const _default: {
+    launch: () => {
+        actions: import("../dist/index").Client<{
+            ping: () => string;
+        }>;
+        worker: import("worker_threads").Worker;
+    };
+};
+export default _default;

--- a/tests/jsWorker.js
+++ b/tests/jsWorker.js
@@ -1,0 +1,4 @@
+import { defineSyncWorker } from "../dist/index.js";
+export default defineSyncWorker(import.meta.filename, {
+    ping: () => "pong!?",
+});


### PR DESCRIPTION
When running in AWS Lambda, the file system is read-only, so writing may fail.
However, libraries might already be in a format executable by Node.js, so try running with the original file.